### PR TITLE
Remove specific references to dependancy versions

### DIFF
--- a/nhs_number_validator.gemspec
+++ b/nhs_number_validator.gemspec
@@ -6,8 +6,8 @@ Gem::Specification.new do |s|
   s.description = 'A simple ActiveRecord validator based on the NHS Number specifications for healthcare providers in the UK.'
   s.license = 'MIT'
   s.homepage = 'https://github.com/mtthwhggns/nhs_number_validator'
-  s.version = '1.0.0'
-  s.add_dependency("activemodel", "~> 0")
-  s.add_development_dependency("rspec", "~> 0")
+  s.version = '1.0.1'
+  s.add_dependency "activemodel"
+  s.add_development_dependency "rspec"
   s.email = 'oss@matthewhiggins.me'
 end


### PR DESCRIPTION
It looks like bundler's behaviour has changed slightly for this style of dependency declaration. We deploy to Heroku and so we cannot control the version of bundler we use. Hence updating the gemspec.
