### PR TITLE
Check for invalid NHS numbers that can pass the checksum validation

### DIFF
--- a/lib/nhs_number_validator.rb
+++ b/lib/nhs_number_validator.rb
@@ -1,6 +1,7 @@
 class NhsNumberValidator < ActiveModel::EachValidator
   def self.valid?(number)
     if self.format_valid?(number)
+      return false if self.same_digit?(number)
       digit_array = number.to_s.split(//)
       if digit_array[9].to_i == check_digit(digit_array)
         true
@@ -20,6 +21,10 @@ class NhsNumberValidator < ActiveModel::EachValidator
 
   def self.format_valid?(number)
     !!(/^\d{10}$/.match(number.to_s))
+  end
+
+  def self.same_digit?(number)
+    !!(/^(\d)\1{9}$/.match(number.to_s))
   end
 
   def self.check_digit(digit_array)

--- a/spec/nhs_number_validator_spec.rb
+++ b/spec/nhs_number_validator_spec.rb
@@ -29,7 +29,7 @@ describe NhsNumberValidator do
       end
     end
     context 'given the invalid NHS numbers' do
-      %w(9434765918 9434765875 9434765916 4012032132).each do |n|
+      %w(9434765918 9434765875 9434765916 4012032132 1111111111 9999999999).each do |n|
         it "#{n} should result in an invalid record" do
           expect(TestPatient.new(nhs_number: n.to_s)).not_to be_valid
         end


### PR DESCRIPTION
Hi,

I *think* that although a 10 digit sequence where all the digits are the same can pass the checksum test, they are officially classed as invalid NHS numbers - I know an ex-NHS person that worked on validating numbers who checked for them.

I thought I'd do a quick pull request rather than just send a comment
